### PR TITLE
teardown and abort loop on IOError and ShutdownSignal

### DIFF
--- a/lib/logstash/inputs/relp.rb
+++ b/lib/logstash/inputs/relp.rb
@@ -84,22 +84,15 @@ class LogStash::Inputs::Relp < LogStash::Inputs::Base
         @logger.warn('Relp client trying to open connection with something other than open:'+e.message)
       rescue Relp::InsufficientCommands
         @logger.warn('Relp client incapable of syslog')
-      rescue IOError, Interrupted
-        if @interrupted
-          # Intended shutdown, get out of the loop
-          @relp_server.shutdown
-          break
-        else
-          # Else it was a genuine IOError caused by something else, so propagate it up..
-          raise
-        end
+      rescue IOError, LogStash::ShutdownSignal
+        teardown
+        break
       end
     end # loop
   end # def run
 
   def teardown
-    @interrupted = true
-    @thread.raise(Interrupted.new)
+    @relp_server.shutdown
   end
 end # class LogStash::Inputs::Relp
 

--- a/spec/inputs/relp_spec.rb
+++ b/spec/inputs/relp_spec.rb
@@ -1,11 +1,12 @@
 # coding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "socket"
+require "logstash/inputs/relp"
 require "logstash/util/relp"
 
-describe "inputs/relp", :socket => true do
+describe LogStash::Inputs::Relp do
 
-  describe "Single client connection" do
+  context "Single client connection" do
     event_count = 10
     port = 5511
     config <<-CONFIG
@@ -36,7 +37,7 @@ describe "inputs/relp", :socket => true do
       th.join
     end # input
   end
-  describe "Two client connection" do
+  context "Two client connection" do
     event_count = 100
     port = 5512
     config <<-CONFIG


### PR DESCRIPTION
Instead of catching Interrupted, catch LogStash::ShutdownSignal and perform teardown, and break out of the loop.

Also removed :socket tag from tests and made them run.