### PR TITLE
Make usage of the new stop semantics to properly shutdown the plugin

### DIFF
--- a/lib/logstash/inputs/relp.rb
+++ b/lib/logstash/inputs/relp.rb
@@ -4,8 +4,6 @@ require "logstash/namespace"
 require "logstash/util/relp"
 require "logstash/util/socket_peer"
 
-
-
 # Read RELP events over a TCP socket.
 #
 # For more information about RELP, see
@@ -48,7 +46,6 @@ class LogStash::Inputs::Relp < LogStash::Inputs::Base
 
   def initialize(*args)
     super(*args)
-    @interrupted = false
     @relp_server = nil
   end # def initialize
 
@@ -93,7 +90,7 @@ class LogStash::Inputs::Relp < LogStash::Inputs::Base
 
   private
   def relp_stream(relpserver,socket,output_queue,client_address)
-    loop do
+    while !stop?
       frame = relpserver.syslog_read(socket)
       @codec.decode(frame["message"]) do |event|
         decorate(event)
@@ -112,7 +109,7 @@ class LogStash::Inputs::Relp < LogStash::Inputs::Base
   public
   def run(output_queue)
     @thread = Thread.current
-    while !@interrupted
+    while !stop?
       begin
         # Start a new thread for each connection.
         Thread.start(@relp_server.accept) do |client|
@@ -146,24 +143,12 @@ class LogStash::Inputs::Relp < LogStash::Inputs::Base
         # NOTE(mrichar1): This doesn't return a useful error message for some reason
         @logger.error("SSL Error", :exception => ssle,
                       :backtrace => ssle.backtrace)
-      rescue LogStash::ShutdownSignal
-        @interrupted = true
-        break
-      rescue IOError, Interrupted
-        if @interrupted
-          # Intended shutdown, get out of the loop
-          @relp_server.shutdown
-          break
-        else
-          # Else it was a genuine IOError caused by something else, so propagate it up..
-          raise
-        end
-      end
+       end
     end # loop
   end # def run
 
-  def teardown
-    @interrupted = true
+  def stop
+    super
     if @relp_server
       @relp_server.shutdown rescue nil
       @relp_server = nil

--- a/lib/logstash/inputs/relp.rb
+++ b/lib/logstash/inputs/relp.rb
@@ -108,7 +108,6 @@ class LogStash::Inputs::Relp < LogStash::Inputs::Base
 
   public
   def run(output_queue)
-    @thread = Thread.current
     while !stop?
       begin
         # Start a new thread for each connection.
@@ -148,7 +147,6 @@ class LogStash::Inputs::Relp < LogStash::Inputs::Base
   end # def run
 
   def stop
-    super
     if @relp_server
       @relp_server.shutdown rescue nil
       @relp_server = nil

--- a/spec/inputs/relp_spec.rb
+++ b/spec/inputs/relp_spec.rb
@@ -1,9 +1,8 @@
 # encoding: utf-8
-require "logstash/util/relp"
 require_relative "../spec_helper"
 require_relative "../support/ssl"
 
-describe "inputs/relp" do
+describe LogStash::Inputs::Relp do
 
   before do
     srand(RSpec.configuration.seed)
@@ -18,6 +17,14 @@ describe "inputs/relp" do
 
   end
 
+  describe "when interrupting the plugin" do
+
+    let(:port) { rand(1024..65532) }
+
+    it_behaves_like "an interruptible input plugin" do
+      let(:config) { { "port" => port } }
+    end
+  end
 
   describe "multiple client connections" do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/inputs/relp"
+require "logstash/util/relp"
 require "socket"
 require "support/client"
 


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

Fixes #10 