### PR TITLE
drop dependency on openssl binary

### DIFF
--- a/logstash-input-relp.gemspec
+++ b/logstash-input-relp.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'cabin'
+  s.add_development_dependency 'flores'
 end
 

--- a/spec/support/ssl.rb
+++ b/spec/support/ssl.rb
@@ -4,13 +4,16 @@ require "stud/temporary"
 module RelpTest
 
   class Certicate
+    require 'flores/pki'
+
     attr_reader :ssl_key, :ssl_cert
 
     def initialize
+      certificate, key = Flores::PKI.generate
       @ssl_cert = Stud::Temporary.pathname("ssl_certificate")
       @ssl_key = Stud::Temporary.pathname("ssl_key")
-
-      system("openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{ssl_key} -out #{ssl_cert} -subj /CN=localhost > /dev/null 2>&1")
+      IO.write(@ssl_cert, certificate.to_pem)
+      IO.write(@ssl_key, key.to_pem)
     end
   end
 


### PR DESCRIPTION
don't rely on openssl being installed to generate
private key + certificate for testing.
uses the ruby-flores library instead

fixes failing tests such as https://travis-ci.org/github/logstash-plugins/logstash-input-relp/jobs/665908497#L512